### PR TITLE
feat: Set overall ui

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -5,7 +5,7 @@ export default class Navigator extends Component {
     return `
         <style>
           .footer_container {
-            width: 450px;
+            width: 480px;
             background-color: #e0e0e0;
             display: flex;
             flex-direction: column;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,17 +5,17 @@ export default class Header extends Component {
         <style>
         .container {
           background-color: #ff9c00;
-          width: 450px;
+          width: 480px;
           height: 45px;
           display: flex;
           justify-content: space-between;
           align-items: center;
-          gap: 30px;
         }
         .logo {
           width: 110px;
           height: 40px;
           float: left;
+          padding: 5px;
         }
         .input_container {
           display: flex;

--- a/src/components/ResultItem.js
+++ b/src/components/ResultItem.js
@@ -11,6 +11,7 @@ export default class ResultItem extends Component {
     return /*html*/ `
     <style>
       .ResultItem{
+        width: 99%;
         height:130px;
         display:flex;
         background-color:#ffebcb;
@@ -33,6 +34,13 @@ export default class ResultItem extends Component {
       }
       .ResultItem_ingredients{
         font-size:small;
+        overflow: hidden;
+        white-space: normal;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        word-break: keep-all;
       }
       .ResultItem_hashtag{
         text-align:center;

--- a/src/pages/CategoryPage.js
+++ b/src/pages/CategoryPage.js
@@ -41,9 +41,10 @@ export default class CategoryPage extends Component {
     return `
       <style>
       .CategoryPage {
+        margin: 0 auto;
+        border: 1px solid #eaeaea;
         width: 480px;
         left: 50%;
-        padding: 10px;
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -51,7 +52,7 @@ export default class CategoryPage extends Component {
       #recommendContainer, #recentContainer {
         text-align: center;
         width: 450px;
-        margin: 10px 0;
+        margin: 11.5px 0;
       }
       h4 { 
         color: orange;
@@ -64,7 +65,7 @@ export default class CategoryPage extends Component {
         height: 110px;
       }
       </style>
-      <div class="CategoryPage">
+      <div class="CategoryPage px-3">
         <div id="header"></div>
         <h4 class="my-3">카테고리</h4>
         <div id="categoryItem"></div>

--- a/src/pages/DetailPage.js
+++ b/src/pages/DetailPage.js
@@ -1,6 +1,5 @@
 import Component from "../core/Component.js";
 import Header from "../components/Header.js";
-import Navigator from "../components/Navigator.js";
 import RecipeItem from "../components/RecipeItem.js";
 import Footer from "../components/Footer.js";
 
@@ -90,9 +89,10 @@ export default class DetailPage extends Component {
     return /*html*/ `
     <style>
     .DetailPage {
+        margin: 0 auto;
+        border: 1px solid #eaeaea;
         width: 480px;
         left: 50%;
-        padding: 10px;
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -149,10 +149,9 @@ export default class DetailPage extends Component {
     }
 </style>
 
-<div class="DetailPage">
+<div class="DetailPage px-3">
     <div id="header"></div>
-    <div id="nav"></div>
-    <h3>오늘은 내가 </h3>
+    <h3 class="mt-4">오늘은 내가 </h3>
     <h3><span class="orange">${this.$state.RCP_NM}</span> 요리사🍴</h3>
     <p class="orange">${this.$state.INFO_ENG}kcal</p>
     <img class="w-50" src="${this.$state.ATT_FILE_NO_MAIN}" />
@@ -185,7 +184,7 @@ export default class DetailPage extends Component {
         <div class="DetailPage_">
             <img class="DetailPage_logo" src="./img/cookcooklogo.png" />이 알려준 레시피가 마음에 들었다면?
         </div>
-        <div class="DetailPage_shareElemSection my-2">
+        <div class="DetailPage_shareElemSection mt-2 mb-4">
             <div class="DetailPage_shareElem"><img src="./img/copy.png" /><span>링크복사</span></div>
             <div class="DetailPage_shareElem"><img src="./img/kakao-talk.png" /><span>카카오톡</span></div>
             <div class="DetailPage_shareElem"><img src="./img/instagram.png" /><span>인스타그램</span></div>
@@ -198,9 +197,7 @@ export default class DetailPage extends Component {
   }
   mounted() {
     const $header = this.$target.querySelector("#header");
-    const $nav = this.$target.querySelector("#nav");
     new Header($header, "detail");
-    new Navigator($nav);
 
     const recipeContainer = this.$target.querySelector("#recipe");
     const keys = Object.keys(this.$state);

--- a/src/pages/DetailPage.js
+++ b/src/pages/DetailPage.js
@@ -161,7 +161,7 @@ export default class DetailPage extends Component {
             <div class="titleText orange">저감조리법 Tip</div>
             <hr width="20%" />
         </div>
-        <div class="content p-3 my-2">${this.$state.RCP_NA_TIP}</div>
+        <div class="content text-center p-3 my-2">${this.$state.RCP_NA_TIP}</div>
     </div>
     <div>
         <div class="DeatailPage_ingredients title my-3">
@@ -169,7 +169,7 @@ export default class DetailPage extends Component {
             <div class="titleText orange">준비물</div>
             <hr width="20%" />
         </div>
-        <div class="content p-3 my-2">${this.$state.RCP_PARTS_DTLS}</div>
+        <div class="content text-center p-3 my-2">${this.$state.RCP_PARTS_DTLS}</div>
     </div>
     <div>
         <div class="DeatailPage_recepi title mt-4">

--- a/src/pages/LandingPage.js
+++ b/src/pages/LandingPage.js
@@ -10,9 +10,10 @@ export default class LandingPage extends Component {
         }
         
         .SplashScreenContainer{
-            width: 400px;
-            height: 600px;
+            width: 480px;
+            height: 853px;
             margin: 0 auto;
+            border: 1px solid #eaeaea;
             display: flex;
             flex-direction: column;
             justify-content: flex-start;

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -62,6 +62,8 @@ export default class SearchPage extends Component {
     return /*html*/ `
     <style>
       .SearchPage{
+        margin: 0 auto;
+        border: 1px solid #eaeaea;
         width:480px;
         left:50%;
         display:flex;
@@ -77,7 +79,7 @@ export default class SearchPage extends Component {
         justify-content:space-between;
       }
     </style>
-      <div class="SearchPage p-3">
+      <div class="SearchPage px-3">
       <div id="header"></div>
       <div id="nav"></div>
       <section class="SearchPage_top">


### PR DESCRIPTION
전반적인 마무리 UI 세팅을 진행했습니다.
- 페이지 전체 width, height 설정 (width: 480px, height: 853px)
- 페이지 전체 가운데 정렬
- 페이지 전체 border 설정 (1px solid #eaeaea)
- 어색한 margin, padding 수정
- ResultItem_ingredients(Search page - ResultItem 내부 컴포넌트) ellipsis 적용
- Detail page에서 nav 삭제