### PR TITLE
feat: filtering ui and function

### DIFF
--- a/src/components/Filter.js
+++ b/src/components/Filter.js
@@ -1,7 +1,19 @@
-import Component from '../core/Component.js';
+import Component from "../core/Component.js";
 
 export default class Filter extends Component {
+  setup() {
+    this.$state = {
+      listVisible: false,
+    };
+  }
+  constructor($target, items, onSort) {
+    super($target);
+    this.items = items;
+    this.onSort = onSort; //콜백함수 저장
+  }
   template() {
+    const { listVisible } = this.$state;
+
     return `
       <style>
         img { 
@@ -10,8 +22,69 @@ export default class Filter extends Component {
           float: right; 
           padding: 5px;
         }
+        ul { 
+          float: right; 
+          list-style: none; 
+          padding: 5px 0;
+        }
+        li { 
+          border: 1px solid #ff9c00;
+          box-shadow: 0px 0px 0px 1px #ff9c00;
+          background-color: #eaeaea !important;
+        }
       </style> 
       <img src = "./img/filter.png">
+      ${
+        listVisible
+          ? `
+        <ul>
+          <li data-sort="nameAsc">👨‍🍳 이름 오름차순</li>
+          <li data-sort="nameDesc">👩‍🍳 이름 내림차순</li>
+          <li data-sort="caloriesLow">👨‍🍳 열량 낮은순</li>
+          <li data-sort="caloriesHigh">👩‍🍳 열량 높은순</li>
+        </ul>
+        `
+          : ""
+      }
     `;
+  }
+
+  setEvent() {
+    this.addEvent("click", "img", this.toggleListVisibility.bind(this));
+
+    this.addEvent("click", "li", (e) => {
+      const sortType = e.target.dataset.sort; // 클릭된 li의 data-sort 속성 값
+      this.sortData(sortType); // 데이터 정렬 함수 호출
+    });
+  }
+
+  // img를 클릭하면 목록이 보이는 메서드
+  toggleListVisibility() {
+    this.setState({ listVisible: !this.$state.listVisible });
+  }
+
+  sortData(sortType) {
+    const { items } = this;
+    let sortedItems = [...items]; // 새 변수에 items 복사
+
+    // sortType에 따라 데이터 정렬
+    if (sortType === "nameAsc") {
+      sortedItems.sort((a, b) => a.RCP_NM.localeCompare(b.RCP_NM, "ko-KR"));
+      // console.log(sortedItems);
+    } else if (sortType === "nameDesc") {
+      sortedItems.sort((a, b) => b.RCP_NM.localeCompare(a.RCP_NM, "ko-KR"));
+      // console.log(sortedItems);
+    } else if (sortType === "caloriesLow") {
+      sortedItems.sort((a, b) => parseInt(a.INFO_ENG) - parseInt(b.INFO_ENG));
+      // console.log(sortedItems);
+    } else if (sortType === "caloriesHigh") {
+      sortedItems.sort((a, b) => parseInt(b.INFO_ENG) - parseInt(a.INFO_ENG));
+      // console.log(sortedItems);
+    }
+
+    // 필터링 및 정렬된 데이터를 로컬 스토리지에 저장
+    localStorage.setItem("filteredData", JSON.stringify(sortedItems));
+    // 부모 컴포넌트로 정렬된 데이터 전달
+    this.onSort(sortedItems);
   }
 }

--- a/src/pages/SearchPage.js
+++ b/src/pages/SearchPage.js
@@ -10,7 +10,27 @@ export default class SearchPage extends Component {
   setup() {
     const category = history.state.category;
     const keyword = history.state.keyword;
-    this.$state = { category: category, keyword: keyword, items: [] };
+    // this.$state 초기화
+    this.$state = {
+      category: category,
+      keyword: keyword,
+      items: SearchLogic(category, keyword), //categorypage에서 불러오면 추후 수정할 예정
+    };
+
+    // 로컬 스토리지에서 필터링된 데이터 가져오기
+    let filteredData = localStorage.getItem("filteredData");
+
+    // 로컬 스토리지에 필터링한 데이터가 있다면, 이를 파싱하여 items에 저장
+    if (filteredData) {
+      const storedCategory = localStorage.getItem("category");
+      const storedKeyword = localStorage.getItem("keyword");
+
+      // 현재의 category 및 keyword와 저장된 category 및 keyword 비교 후 일치하면 filteredData 사용
+      if (storedCategory === category && storedKeyword === keyword) {
+        this.$state.items = JSON.parse(filteredData);
+        return;
+      }
+    }
   }
 
   template() {
@@ -34,6 +54,11 @@ export default class SearchPage extends Component {
             width: 100%;
             display: flex;
             justify-content: space-between;
+            position: relative;
+        }
+        #filter {
+          position: absolute;
+          right: 0;
         }
     </style>
     <div class="SearchPage px-3">
@@ -51,7 +76,6 @@ export default class SearchPage extends Component {
   }
 
   mounted() {
-    this.$state.items = SearchLogic();
     const $searchPageTop = this.$target.querySelector(".SearchPage_top");
     const $resultBlock = document.createElement("div");
     $resultBlock.insertAdjacentHTML(
@@ -70,7 +94,10 @@ export default class SearchPage extends Component {
     const $pagination = this.$target.querySelector("#paginationContainer");
     new Pagination($pagination, this.$state.items);
     const $filter = this.$target.querySelector("#filter");
-    new Filter($filter);
+    new Filter($filter, this.$state.items, (sortedItems) => {
+      // Filter 컴포넌트에서 데이터가 정렬되면 이 콜백 함수를 호출하여 상태 업데이트
+      this.setState({ items: sortedItems });
+    });
 
     const $header = this.$target.querySelector("#header");
     new Header($header, {


### PR DESCRIPTION
SearchPage에 있는 filter ui 및 기능을 구현하였습니다.
* img를 클릭하면 목록이 보임.
* 해당 목록을 클릭하면 본문 item들을 정렬해줌.
* 정렬된 데이터를 localstorage에 저장.

* SearchPage에서 filteredData(localstorage에 있는 정렬된 데이터)가 존재하면, 이를 파싱하여 items에 저장
* 존재하지 않으면 SearchLogic를 이용한 원본 데이터 사용 (이는 categorypage에서 불러오게 되면 추후 수정할 예정임)