### PR TITLE
feat: recentitem function

### DIFF
--- a/components/RecentItem.js
+++ b/components/RecentItem.js
@@ -1,9 +1,59 @@
-import Component from '../core/Component.js';
+import Component from "../core/Component.js";
 
 export default class Recent extends Component {
+  constructor($target, props) {
+    super($target, props);
+    this.currentIndex = 0;
+  }
+  setup() {
+    const defaultItemData = {
+      imgUrl: "https://ifh.cc/g/FnGKV7.png",
+      name: "최근 본 레시피가 없습니다🍪",
+    };
+    const defaultitem = Array(3).fill(defaultItemData);
+
+    // 'recentRecipe' 키의 값이 없다면 defaultitem으로 설정
+    if (!localStorage.getItem("recentRecipe")) {
+      localStorage.setItem("recentRecipe", JSON.stringify(defaultitem));
+    }
+
+    this.$state = {
+      currentIndex: 0,
+      recentRecipe: JSON.parse(localStorage.getItem("recentRecipe")) || [],
+    };
+  }
+
   template() {
-    const recentlyList = this.$props.recentlyList || [];
-    
+    const recentlyList = this.$state.recentRecipe;
+
+    const batchedFoodList = []; // 3개씩 batch로 묶음
+    for (let i = 0; i < recentlyList.length; i += 3) {
+      const batch = recentlyList.slice(i, i + 3);
+      batchedFoodList.push(batch);
+    }
+    const currentBatch = batchedFoodList[this.$state.currentIndex];
+
+    // 슬라이드 생성
+    let slides = currentBatch.map(
+      (food, index) => `
+         <div class="slide" key="${index}">
+           <img src="${food.imgUrl}" alt="${food.name}">
+           <div class="image-name ${
+             food.name.length >= 10 ? "long-text" : ""
+           }">${food.name}</div>
+         </div>
+       `
+    );
+
+    // 빈 공간이 생기지 않게 default img 추가
+    while (slides.length < 3) {
+      slides.push(`
+            <div class="slide">
+              <img src="https://ifh.cc/g/FnGKV7.png">
+            </div>
+        `);
+    }
+
     return `
       <style>
         .slide {
@@ -20,27 +70,24 @@ export default class Recent extends Component {
         .slide img {
           width: 100%;
           height: 100%;
+          object-fit: cover;
+          cursor: pointer;
         }
         .image-name {
           position: absolute;
           padding: 3px 0;
-          top: 40%;
-          width: 90%;
+          bottom: 5px;
+          width: 110px;
           font-size: 12px;
           font-weight: bold;
           background-color: rgba(227, 227, 227, 0.632);
-          visibility: hidden;
-          opacity:0;
-          transition: top 0.3s, opacity 0.3s;
-        }
-        .slide:hover .image-name {
-          visibility: visible;
-          opacity: 1;
+          cursor: pointer;
+          line-height: 1.2em;
         }
         .image-name.long-text {
-          top: 30%;
+          word-break: break-all;
         }
-        .slider-btn {
+        .recent-slider-btn {
           cursor: pointer;
           font-size: 60px;
           height: 100px;
@@ -49,16 +96,68 @@ export default class Recent extends Component {
         }
       </style>
 
-      <div class="slider-btn" id="prevBtn">&#8249;</div>
+      ${
+        this.$state.recentRecipe.length > 3
+          ? `<style> .recent-slider-btn { visibility: visible; } </style>`
+          : `<style> .recent-slider-btn { visibility: hidden; } </style>`
+      }
 
-      ${recentlyList.map((food, index) => `
-        <div class="slide" key="${index}">
-          <img src="${food.imgUrl}" alt="${food.name}">
-          <div class="image-name ${food.name.length >= 10 ? 'long-text' : ''}">${food.name}</div>
-        </div>
-      `).join('')}
+      <div class="recent-slider-btn" id="prevBtn">&#8249;</div>
 
-      <div class="slider-btn" id="nextBtn">&#8250;</div>
+      ${slides.join("")}
+
+      <div class="recent-slider-btn" id="nextBtn">&#8250;</div>
     `;
+  }
+  setEvent() {
+    this.addEvent("click", "#prevBtn", (e) => {
+      this.prevSlide.bind(this)();
+    });
+    this.addEvent("click", "#nextBtn", (e) => {
+      this.nextSlide.bind(this)();
+    });
+
+    // .slide를 클릭하면 해당 detailpage로 이동
+    this.addEvent("click", ".slide", (e) => {
+      const clickedElem = e.target.closest(".slide");
+      const foodName = clickedElem.querySelector("img").getAttribute("alt");
+
+      // 원본 items 배열과 일치하는 데이터
+      const selectedItem = this.$props.items.find(
+        (item) => item.RCP_NM === foodName
+      );
+
+      if (selectedItem) {
+        history.pushState(
+          { data: selectedItem, keyword: "" },
+          null,
+          location.href.replace("category", `detail/${selectedItem.RCP_SEQ}`)
+        );
+        history.go(0);
+      }
+    });
+  }
+
+  prevSlide() {
+    const { currentIndex } = this.$state;
+    const batchedFoodListLength = Math.ceil(
+      this.$state.recentRecipe.length / 3
+    );
+    if (currentIndex === 0) {
+      this.setState({ currentIndex: batchedFoodListLength - 1 });
+    } else {
+      this.setState({ currentIndex: currentIndex - 1 });
+    }
+  }
+  nextSlide() {
+    const { currentIndex } = this.$state;
+    const batchedFoodListLength = Math.ceil(
+      this.$state.recentRecipe.length / 3
+    );
+    if (currentIndex === batchedFoodListLength - 1) {
+      this.setState({ currentIndex: 0 });
+    } else {
+      this.setState({ currentIndex: currentIndex + 1 });
+    }
   }
 }

--- a/components/Recommend.js
+++ b/components/Recommend.js
@@ -12,8 +12,6 @@ export default class Recommend extends Component {
   }
   template() {
     const { batchedFoodList } = this.$props;
-
-    // 현재 인덱스에 해당하는 배치 가져오기
     const currentBatch = batchedFoodList[this.$state.currentIndex];
 
     return `
@@ -28,30 +26,26 @@ export default class Recommend extends Component {
           width: 110px;
           height: 110px;
           position: relative;
-          cursor: pointer;
         }
         .slide img {
           width: 100%;
           height: 100%;
+          object-fit: cover;
+          cursor: pointer;
         }
         .image-name {
           position: absolute;
           padding: 3px 0;
-          top: 40%;
-          width: 90%;
+          bottom: 5px;
+          width: 110px;
           font-size: 12px;
           font-weight: bold;
           background-color: rgba(227, 227, 227, 0.632);
-          visibility: hidden;
-          opacity:0;
-          transition: top 0.3s, opacity 0.3s;
-        }
-        .slide:hover .image-name {
-          visibility: visible;
-          opacity: 1;
+          cursor: pointer;
+          line-height: 1.2em;
         }
         .image-name.long-text {
-          top: 30%;
+          word-break: break-all;
         }
         .slider-btn {
           cursor: pointer;
@@ -92,16 +86,13 @@ export default class Recommend extends Component {
     // .slide를 클릭하면 해당 detailpage로 이동
     this.addEvent("click", ".slide", (e) => {
       const clickedElem = e.target.closest(".slide");
-
-      // 클릭된 음식의 alt 속성에서 food name 가져오기
       const foodName = clickedElem.querySelector("img").getAttribute("alt");
 
-      // 원본 items 배열에서 foodName과 일치하는 데이터 찾기
+      // 원본 items 배열과 일치하는 데이터
       const selectedItem = this.$props.items.find(
         (item) => item.RCP_NM === foodName
       );
 
-      // detail 페이지로 이동
       if (selectedItem) {
         history.pushState(
           { data: selectedItem, keyword: "" },

--- a/pages/CategoryPage.js
+++ b/pages/CategoryPage.js
@@ -73,16 +73,18 @@ export default class CategoryPage extends Component {
     const $sliderContainer = this.$target.querySelector(".slider");
 
     // 중복되지 않는 무작위 숫자를 생성하는 메서드
-    function getRandomNumbers(min, max, count) {
+    const getRandomNumbers = (min, max, count) => {
       const randomNumbers = new Set();
-
       while (randomNumbers.size < count) {
         const randomNumber = Math.floor(Math.random() * (max - min + 1)) + min;
-        randomNumbers.add(randomNumber);
+        const imgUrl = this.$state.items[randomNumber].ATT_FILE_NO_MAIN;
+        // img가 존재할 때만 randomNumber를 추가하도록
+        if (imgUrl) {
+          randomNumbers.add(randomNumber);
+        }
       }
-
       return Array.from(randomNumbers);
-    }
+    };
 
     const selectedNumbers = getRandomNumbers(1, 1001, 9);
 
@@ -100,16 +102,13 @@ export default class CategoryPage extends Component {
 
     new Recommend($sliderContainer, {
       batchedFoodList,
-      items: this.$state.items, //원본 데이터도 같이 넘겨줌
+      items: this.$state.items,
     });
 
     const $recentItemContainer = this.$target.querySelector(".slider-recent");
-    const recentlyList = this.$state.map((item) => ({
-      // 임의로 받아온 배열입니다.
-      imgUrl: item.ATT_FILE_NO_MAIN,
-      name: item.RCP_NM,
-    }));
-    new RecentItem($recentItemContainer, { recentlyList });
+    new RecentItem($recentItemContainer, {
+      items: this.$state.items,
+    });
 
     const $footer = this.$target.querySelector("#footer");
     new Footer($footer);

--- a/pages/DetailPage.js
+++ b/pages/DetailPage.js
@@ -197,17 +197,17 @@ export default class DetailPage extends Component {
     });
 
     const hideBtn = this.$target.querySelector("#hideBtn");
-    hideBtn.addEventListener('click',() => {
+    hideBtn.addEventListener("click", () => {
       const images = this.$target.querySelectorAll(".RecipeItem img");
       hideBtn.classList.toggle("buttonBefore");
       hideBtn.classList.toggle("buttonAfter");
-      images.forEach(image=>image.classList.toggle("hidden"));
-    })
+      images.forEach((image) => image.classList.toggle("hidden"));
+    });
 
     const printBtn = this.$target.querySelector("#printBtn");
-    printBtn.addEventListener('click',() => {
+    printBtn.addEventListener("click", () => {
       window.print();
-    })
+    });
 
     const recipeContainer = this.$target.querySelector("#recipe");
     const keys = Object.keys(this.$state);
@@ -226,6 +226,28 @@ export default class DetailPage extends Component {
       this.$state.RCP_NA_TIP;
     this.$target.querySelector(".DetailPage_RCP_PARTS_DTLS").innerHTML =
       this.$state.RCP_PARTS_DTLS;
+
+    // 이전에 저장된 데이터 가져오기
+    const previousArray = JSON.parse(localStorage.getItem("recentRecipe"));
+
+    const newItem = {
+      imgUrl: this.$state.ATT_FILE_NO_MAIN,
+      name: this.$state.RCP_NM,
+    };
+
+    // 중복되지 않은 데이터만 배열 앞에 추가
+    if (!previousArray.some((item) => item.name === newItem.name)) {
+      if (
+        previousArray.length >= 3 &&
+        previousArray.some(
+          (item) => item.name === "최근 본 레시피가 없습니다🍪"
+        )
+      ) {
+        previousArray.pop(); // defaultitem가 있을때, 삭제
+      }
+      previousArray.unshift(newItem);
+      localStorage.setItem("recentRecipe", JSON.stringify(previousArray));
+    }
 
     manualImgKeys.forEach((manualImgKey, i) => {
       const item = document.createElement("div");


### PR DESCRIPTION
categorypage의 최근 본 레시피 기능을 구현하였습니다.
=====================================

RecentItem.js
----------------
* 사용자가 클릭한 레시피가 없을 시, default 값 설정 
![image](https://github.com/elice-cookcook/cookcook/assets/109502469/87865a91-c030-4dd9-9002-ac4d6230daac)

* recentRecipe 배열을 3개씩 묶어준 배치로 slide 생성
  * 이때, slides길이가 3개 미만이면, 빈 공간이 생기므로 이를 방지하기 위해 img 추가
 
* slides가 3개 이하 일때는 화살표가 보이지 않도록 설정
* 해당 slide를 클릭하면 해당 레시피가 보이도록 detailpage로 이동

DetailPage.js
---------------
* localstorage에 저장된 recentRecipe 데이터를 가져옴
* 배열에 추가하기 전, 
  * default 값이 존재한다면 pop
  * 존재하지 않다면 unshift로 배열 앞에 추가하여 업데이트
![image](https://github.com/elice-cookcook/cookcook/assets/109502469/c633d90d-18cf-4bd9-9aeb-44c1d299099b)


이 외에 수정한 부분 
------------------------
* Recommend.js
  * image-name 일립시스 설정

* CategoryPage.js
  * 중복되지 않는 무작위 숫자를 생성하는 메서드(getRandomNumbers)에 imgUrl이 존재할때만 해당 일련번호를 추가